### PR TITLE
Expand mobile game view and restore stage content

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ミニマリオゲーム</title>
+    <title>ミニヒーローゲーム</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -66,7 +66,7 @@
     
     <!-- ゲーム説明 -->
     <div id="instructions">
-        <h3>🎮 スーパーマリオアドベンチャー v2.0</h3>
+        <h3>🎮 スーパーヒーローアドベンチャー v2.0</h3>
         <div class="controls-info">
             <div class="control-section">
                 <h4>🖥️ パソコン操作</h4>

--- a/script.js
+++ b/script.js
@@ -559,14 +559,16 @@ function gameLoop(timestamp) {
 }
 
 function resizeCanvas() {
-    const scale = Math.min(window.innerWidth / CAM_W, window.innerHeight / CAM_H);
+    const height = window.innerHeight * 0.75;
+    const scale = height / CAM_H;
+    cv.style.height = `${height}px`;
     cv.style.width = `${CAM_W * scale}px`;
-    cv.style.height = `${CAM_H * scale}px`;
 }
 
 window.addEventListener('resize', resizeCanvas);
 
 document.addEventListener('DOMContentLoaded', () => {
+    generateStage(currentStage, currentWorld);
     resizeCanvas();
     requestAnimationFrame(gameLoop);
 });

--- a/style.css
+++ b/style.css
@@ -51,9 +51,10 @@ html, body {
 #game-container {
   display: flex;
   justify-content: center;
-  align-items: center;
-  min-height: 50vh;
-  padding: 20px 0;
+  align-items: flex-start;
+  height: 75vh;
+  padding: 0;
+  overflow-x: auto;
 }
 
 /* キャンバス */
@@ -64,9 +65,9 @@ canvas {
   background: #87CEEB;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   image-rendering: pixelated;
-  width: 100%;
-  max-width: 100%;
-  height: auto;
+  height: 100%;
+  width: auto;
+  max-width: none;
   touch-action: none;
 }
 
@@ -328,7 +329,7 @@ canvas {
 /* 横向きスマートフォン対応 */
 @media (max-width: 768px) and (orientation: landscape) {
   #game-container {
-      min-height: 30vh;
+      height: 75vh;
       padding: 10px 0;
   }
   


### PR DESCRIPTION
## Summary
- Rename "マリオ" references to "ヒーロー" in the game title and description
- Expand the game canvas to occupy 75% of the viewport height and adjust layout for mobile
- Generate stage data on load so enemies, blocks, and other elements appear

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c5c229ccc8330ad7a70c43548973f